### PR TITLE
open web3 rpccorsdomain to allow Remix broswer ide

### DIFF
--- a/server/commands/config.go
+++ b/server/commands/config.go
@@ -130,6 +130,8 @@ rpc = true
 rpcapi = "cmt,eth,net,web3,personal,admin"
 rpcaddr = "0.0.0.0"
 rpcport = 8545
+rpccorsdomain = "*"
+
 ws = false
 verbosity = 1
 


### PR DESCRIPTION
Simple patch to allow default web3 rpc accept an rpccorsdomain which is any normal Remix IDE need unless they are running it as a fix service but then they should know enough to change the default to a specific ip. 

Signed-off-by: Alex Lau (AvengerMoJo) <avengermojo@gmail.com>