### PR TITLE
Correct Byzantine validator punishment logic

### DIFF
--- a/app/base.go
+++ b/app/base.go
@@ -236,8 +236,8 @@ func (app *BaseApp) EndBlock(req abci.RequestEndBlock) (res abci.ResponseEndBloc
 			}
 
 			stake.PunishByzantineValidator(pk)
-			app.ByzantineValidators = app.ByzantineValidators[:0]
 		}
+		app.ByzantineValidators = app.ByzantineValidators[:0]
 	}
 
 	// punish the absent validators


### PR DESCRIPTION
In current implementation, only the first Byzantine
validator will be punished. Should clear the list
after punishing all of them.

Signed-off-by: Xin Qian <turkeycock@gmail.com>